### PR TITLE
Feat/dashboard claimmap support

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -264,6 +264,11 @@ public sealed class OpenIdConnectOptions
     /// </summary>
     public string RequiredClaimValue { get; set; } = "";
 
+    /// <summary>
+    /// Gets or sets the optional value to configure the ClaimActions of <see cref="Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions"/>
+    /// </summary>
+    public string? ClaimActions { get; set; }
+
     public string[] GetNameClaimTypes()
     {
         Debug.Assert(_nameClaimTypes is not null, "Should have been parsed during validation.");

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -735,6 +735,50 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
                     // Avoid "message.State is null or empty" due to use of CallbackPath above.
                     options.SkipUnrecognizedRequests = true;
+
+                    // Configure additional ClaimActions
+                    var claimActionsMap = dashboardOptions.Frontend.OpenIdConnect.ClaimActions;
+                    if (!string.IsNullOrEmpty(claimActionsMap))
+                    {
+                        var actions = claimActionsMap.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        foreach (var action in actions)
+                        {
+                            var ops = action.Split(':');
+                            switch (ops[0], ops.Length)
+                            {
+                                case ("Delete", _):
+                                    foreach (var item in ops.Skip(1))
+                                    {
+                                        options.ClaimActions.DeleteClaim(item);
+                                    }
+                                    break;
+
+                                case ("MapUniqueJsonKey", 3):
+                                    options.ClaimActions.MapUniqueJsonKey(ops[1], ops[2]);
+                                    break;
+                                case ("MapUniqueJsonKey", > 3):
+                                    options.ClaimActions.MapUniqueJsonKey(ops[1], ops[2], ops[3]);
+                                    break;
+
+                                case ("MapJsonKey", 3):
+                                    options.ClaimActions.MapJsonKey(ops[1], ops[2]);
+                                    break;
+                                case ("MapJsonKey", > 3):
+                                    options.ClaimActions.MapJsonKey(ops[1], ops[2], ops[3]);
+                                    break;
+
+                                case ("MapJsonSubKey", 4):
+                                    options.ClaimActions.MapJsonSubKey(ops[1], ops[2], ops[3]);
+                                    break;
+                                case ("MapJsonSubKey", > 4):
+                                    options.ClaimActions.MapJsonSubKey(ops[1], ops[2], ops[3], ops[4]);
+                                    break;
+
+                                default:
+                                    throw new ArgumentException("Invalid parameter count or not supported claim action type");
+                            }
+                        }
+                    }
                 });
                 break;
             case FrontendAuthMode.BrowserToken:

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -775,7 +775,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                                     break;
 
                                 default:
-                                    throw new ArgumentException($"Invalid parameter count or not supported claim action type: {ops[0]} with {ops.Length - 1} parameters");
+                                    throw new ArgumentException($"Invalid parameter count or not supported claim action type: {ops[0]} with {ops.Length - 1} parameters {action}");
                             }
                         }
                     }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -775,7 +775,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                                     break;
 
                                 default:
-                                    throw new ArgumentException("Invalid parameter count or not supported claim action type");
+                                    throw new ArgumentException($"Invalid parameter count or not supported claim action type: {ops[0]} with {ops.Length - 1} parameters");
                             }
                         }
                     }


### PR DESCRIPTION
## Description

Try to support configure additional ClaimMap for the OpenIdConnect authentication

Fixes #7755 

verified locally

![Image](https://github.com/user-attachments/assets/f16304f6-ba77-4ede-b11a-b0fdc9c6d6dc)

usage example:

```json
{
  "Authentication": {
    "Schemes": {
      "OpenIdConnect": {
        "Authority": "https://id.weihanli.xyz",
        "ClientId": "aspire",
        "ClientSecret": "",
        "GetClaimsFromUserInfoEndpoint": true,
        "Scope": ["roles"]
      }
    }
  },
  "Dashboard": {
    "Frontend": {
      "AuthMode": "OpenIdConnect",
      "OpenIdConnect": {
        "RequiredClaimType": "role",
        "RequiredClaimValue": "Aspire",
        "ClaimActions": "MapJsonKey:role:role"
      }
    }
  }
}

```

environment sample:
```yaml
  - name: Dashboard__Frontend__AuthMode
    value: "OpenIdConnect"
  - name: Dashboard__Frontend__OpenIdConnect__ClaimActions
    value: "MapJsonKey:role:role"
  - name: Dashboard__Frontend__OpenIdConnect__RequiredClaimType
    value: "role"
  - name: Dashboard__Frontend__OpenIdConnect__RequiredClaimValue
    value: "Aspire"
```


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
